### PR TITLE
fix(makecheck): potential unexpected file path prefix trimming

### DIFF
--- a/cmd/makecheck/command.go
+++ b/cmd/makecheck/command.go
@@ -39,7 +39,7 @@ func commandHandler(c *cli.Context) error {
 		if strings.Contains(strings.ToLower(fi.Name()), ".ds_store") {
 			return nil
 		}
-		srcPath := filepath.ToSlash(strings.TrimPrefix(strings.Replace(filePath, srcDir, "", -1), string(filepath.Separator)))
+		srcPath := filepath.ToSlash(strings.TrimPrefix(strings.TrimPrefix(filePath, srcDir), string(filepath.Separator)))
 		if !fi.Mode().IsRegular() {
 			return nil
 		}


### PR DESCRIPTION
especially for the case when the source path is equal to '.'